### PR TITLE
build: Support prefix dir in .config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+*.o
+*.so
+*.swp
+.config

--- a/guider
+++ b/guider
@@ -15,11 +15,12 @@ if [ ! $PYTHON_EXEC ]
         exit
 fi
 
-
+PREFIX_DIR=
 OBJFILE=guider.pyc
+LIB_DIR=/usr/lib
 SHARE_DIR=/usr/share/guider
 LAUNCHER_DIR=$(dirname "$0")
-LIBPATH=$LD_LIBRARY_PATH:$LAUNCHER_DIR:/usr/lib:$SHARE_DIR
+LIBPATH=$LAUNCHER_DIR:$LIB_DIR:$SHARE_DIR:$LD_LIBRARY_PATH
 ERRMSG="try to rebuild or to set proper PYC_DIR variable for guider.pyc"
 
 if [ $PYC_DIR ]
@@ -36,6 +37,9 @@ elif [ -f $LAUNCHER_DIR/$OBJFILE ]
 elif [ -f $SHARE_DIR/$OBJFILE ]
     then
         LD_LIBRARY_PATH=$LIBPATH $PYTHON_EXEC $SHARE_DIR/$OBJFILE $*
+elif [ -f $PREFIX_DIR/share/guider/$OBJFILE ]
+    then
+        LD_LIBRARY_PATH=$LIBPATH $PYTHON_EXEC $PREFIX_DIR/share/guider/$OBJFILE $*
 else
     echo "[Error] Fail to find $OBJFILE," $ERRMSG 
 fi


### PR DESCRIPTION
It'd be better to support directory prefix for installation.  The user
can write .config file as follows:

  $ cat .config
  prefix = /home/honggyu/usr

This allows guider to install required scripts and binaries to the
prefixed directory location.  If there is no .config file, the
installation location is not changed as before.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>