### PR TITLE
Add deadline scheduler in schedList

### DIFF
--- a/guider/guider.py
+++ b/guider/guider.py
@@ -403,6 +403,7 @@ class ConfigManager(object):
         'B', # 3: BATCH #
         'N', # 4: NONE #
         'I', # 5: IDLE #
+        'D', # 6: DEADLINE #
         ]
 
     # Define statm of process #


### PR DESCRIPTION
The schedList haven't supported deadline
scheduler so far. If a process run with
SCHED_DEADLINE, guider dies.

Fix by adding 'D' at 6th location of schedList.

Signed-off-by: Jungsu Sohn <jsson98@gmail.com>