### PR TITLE
build: Add checking .pyc before moving

### DIFF
--- a/guider/Makefile
+++ b/guider/Makefile
@@ -75,7 +75,9 @@ all: $(TARGET_PYC) $(OBJS) $(TARGET_LIB)
 
 $(TARGET_PYC): $(TARGET_PY)
 	$(QUIET_PCC)$(PCC) $(PFLAGS) $^
-	$(Q)-$(MV) __pycache__/$(MODULE)*.pyc $(CURDIR)/$(MODULE).pyc
+	$(Q)if [ -f __pycache__/$(MODULE)*.pyc ]; then \
+		$(MV) __pycache__/$(MODULE)*.pyc $(CURDIR)/$(MODULE).pyc; \
+	fi
 
 $(OBJS): $(SRCS)
 	$(QUIET_CC)$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $^


### PR DESCRIPTION
A .pyc is created under __pycache__ after python 3.2. So it is needed to
check whether the file is under the __pycache.

Signed-off-by: Jungsu Sohn <jsson98@gmail.com>