### PR TITLE
Fix to properly show top level help message

### DIFF
--- a/guider/guider.py
+++ b/guider/guider.py
@@ -14767,7 +14767,7 @@ Copyright:
                 SystemManager.printStreamEnable == False):
             try:
                 if sys.platform.startswith('linux'):
-                    SystemManager.pipeForPrint = os.popen('less -E', 'w')
+                    SystemManager.pipeForPrint = os.popen('less -FRSX', 'w')
                 elif sys.platform.startswith('win'):
                     SystemManager.pipeForPrint = os.popen('more', 'w')
                 else:


### PR DESCRIPTION
Previously, "guider -h" doesn't show anything because of incorrect less
setting, so this fixes the problem.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>