### PR TITLE
FIX README.md Build & Installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Table of contents
    * [Output](#Output)
    * [How to use](#How-to-use)
    * [Requirement](#Requirement)
-   * [Build & Installation](#Build-&-Installation)
+   * [Build & Installation](#Build--Installation)
    * [Kernel Configuration](#Kernel-Configuration)
    * [Help](#Help)
 <!--te-->


### PR DESCRIPTION
README 에서 Build & Installation 링크가 제대로 걸려있지 않아서 수정했습니다.