### PR TITLE
fix 404 errors when refresh page

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -72,8 +72,9 @@ def createApp(config_filename=None):
     # import NetworkManger form Guider #
     from guider import NetworkManager
 
-    @app.route('/')
-    def index():
+    @app.route('/', defaults={'path': ''})
+    @app.route('/<path>')
+    def index(path):
         print("route /")
 
         return render_template('index.html', server_addr=request.host_url)


### PR DESCRIPTION
close #110 

경로가 `localhost:5000/dashboard`일 때 새로고침 시, 이 경로는 우선 flask 서버에게 전달됩니다.

하지만 기존 flask route에는 루트 경로(/)만 지정되어 있었기에 404 에러가 났습니다.

하위 경로가 들어와도 index 메소드가 처리하도록 설정했습니다.