### PR TITLE
Remove Dependencies on flask-mongoengine.

### DIFF
--- a/agent/front-vue/src/pages/History.vue
+++ b/agent/front-vue/src/pages/History.vue
@@ -101,7 +101,7 @@ export default {
       device: null,
       count: -1,
       db_start: null,
-      options: [{ value: null, option: "Loading.." }],
+      options: [{ value: null, text: "Loading.." }],
       db_end: null
     };
   },
@@ -116,20 +116,27 @@ export default {
       return Date.parse(date) / 1000;
     },
     async getDevices() {
-      const response = await fetch("http://localhost:8000/devices");
-      const responseOK = response && response.status == 200;
-      if (responseOK) {
-        const body = await response.json();
-        if (body && body.status == "ok") {
-          const devices = body.devices || body.data;
-          this.options = [{ value: null, text: "Select Device" }];
-          for (let device of devices) {
-            this.options.push({
-              value: device,
-              text: `${device.mac_addr}(${device.count})`
-            });
+      try {
+        const response = await fetch("http://localhost:8000/devices");
+        const responseOK = response && response.status == 200;
+        if (responseOK) {
+          const body = await response.json();
+          if (body && body.status == "ok") {
+            const devices = body.devices || body.data;
+            this.options = [{ value: null, text: "Select Device" }];
+            for (let device of devices) {
+              this.options.push({
+                value: device,
+                text: `${device.mac_addr}(${device.count})`
+              });
+            }
           }
+          else throw Error(body.msg || "Internal Server Error");
         }
+      }
+      catch(e){
+        this.options = [{ value:null, text: e}]
+        this.errMsg = e
       }
     },
     getMetaData() {
@@ -139,23 +146,6 @@ export default {
       this.db_end = this.tsToPrettyDate(this.device.end);
       this.end = this.tsToISOString(this.device.end);
       this.sampleNum = this.count < 80 ? this.count : 80;
-      // const response = await fetch("http://localhost:8000/dataset");select
-      // const responseOK = response && response.status == 200;
-      // if (responseOK) {
-      //   const body = await response.json();
-      //   if (body && body.status == "ok") {
-      //     const { data, meta } = body;
-      //     if (data.length) {
-      //       this.count = meta.count || 0;
-      //       this.db_start = this.tsToPrettyDate(meta.start);
-      //       this.start = this.tsToISOString(meta.start);
-      //       this.db_end = this.tsToPrettyDate(meta.end);
-      //       this.end = this.tsToISOString(meta.end);
-      //     } else {
-      //       this.count = 0;
-      //     }
-      //   }
-      // }
     },
     async getData() {
       // init values
@@ -185,7 +175,7 @@ export default {
               .forEach(x => {
                 this.dataSet.setGuiderData(x);
               });
-          } else throw Error("Internal Server Error");
+          } else throw Error( body.msg || "Internal Server Error");
         } else throw Error("Failed to load body");
       } catch (e) {
         this.errMsg = e;

--- a/agent/monitoring/controllers.py
+++ b/agent/monitoring/controllers.py
@@ -22,6 +22,10 @@ class Devices(Resource):
         pass
 
     def get(self):
+        from app import is_connected
+        if not is_connected:
+            return jsonify(dict(status="failed", msg="failed to connect mongoDB"))
+
         from monitoring.models import Devices
         if Devices.objects.count() == 0:
             find_devices_from_db()
@@ -44,6 +48,9 @@ class Dataset(Resource):
         pass
 
     def get(self):
+        from app import is_connected
+        if not is_connected:
+            return jsonify(dict(status="failed", msg="failed to connect mongoDB"))
         args = request.args
         start = args.get('start', None)
         end = args.get('end', None)
@@ -77,7 +84,7 @@ class Dataset(Resource):
             num = int(num)
         except Exception as e:
             print('Failed to parse start, end ', e)
-            return jsonify(dict(status="failed", data=[], msg="Failed to parse start, end"))
+            return jsonify(dict(status="failed", msg="Failed to parse start, end"))
         datas = list(Datas.objects().order_by('+timestamp').all())
         print(len(datas), start, end)
         # TODO: Quering Database in range, Not processing everything.
@@ -155,6 +162,7 @@ def find_devices_from_db():
                 count=1,
                 mac_addr=data.mac_addr
             )
+    from monitoring.models import Devices
     results = list(devices.values())
     for result in results:
         Devices(**result).save()

--- a/agent/monitoring/models.py
+++ b/agent/monitoring/models.py
@@ -1,50 +1,52 @@
-from flask_mongoengine import MongoEngine
+#from flask_mongoengine import MongoEngine
+from mongoengine import EmbeddedDocumentField, Document, IntField, \
+    StringField, DateTimeField, EmbeddedDocument, connect
 from datetime import datetime
 
-db = MongoEngine()
+connect('guider')
 
 
-class CPU(db.EmbeddedDocument):
-    kernel = db.IntField(default=0)
-    user = db.IntField(default=0)
-    irq = db.IntField(default=0)
-    nrCore = db.IntField(default=0)
-    total = db.IntField(default=0)
+class CPU(EmbeddedDocument):
+    kernel = IntField(default=0)
+    user = IntField(default=0)
+    irq = IntField(default=0)
+    nrCore = IntField(default=0)
+    total = IntField(default=0)
 
 
-class Memory(db.EmbeddedDocument):
-    kernel = db.IntField(default=0)
-    cache = db.IntField(default=0)
-    free = db.IntField(default=0)
-    anon = db.IntField(default=0)
-    total = db.IntField(default=0)
+class Memory(EmbeddedDocument):
+    kernel = IntField(default=0)
+    cache = IntField(default=0)
+    free = IntField(default=0)
+    anon = IntField(default=0)
+    total = IntField(default=0)
 
 
-class Storage(db.EmbeddedDocument):
-    free = db.IntField(default=0)
-    usage = db.IntField(default=0)
-    total = db.IntField(default=0)
+class Storage(EmbeddedDocument):
+    free = IntField(default=0)
+    usage = IntField(default=0)
+    total = IntField(default=0)
 
 
-class Network(db.EmbeddedDocument):
-    inbound = db.IntField(default=0)
-    outbound = db.IntField(default=0)
+class Network(EmbeddedDocument):
+    inbound = IntField(default=0)
+    outbound = IntField(default=0)
 
 
-class Datas(db.Document):
-    timestamp = db.DateTimeField(default=datetime.utcnow)
-    mac_addr = db.StringField()
-    cpu = db.EmbeddedDocumentField(CPU)
-    memory = db.EmbeddedDocumentField(Memory)
-    storage = db.EmbeddedDocumentField(Storage)
-    network = db.EmbeddedDocumentField(Network)
+class Datas(Document):
+    timestamp = DateTimeField(default=datetime.utcnow)
+    mac_addr = StringField()
+    cpu = EmbeddedDocumentField(CPU)
+    memory = EmbeddedDocumentField(Memory)
+    storage = EmbeddedDocumentField(Storage)
+    network = EmbeddedDocumentField(Network)
 
 
-class Devices(db.Document):
-    mac_addr = db.StringField()
-    start = db.DateTimeField()
-    end = db.DateTimeField()
-    count = db.IntField()
+class Devices(Document):
+    mac_addr = StringField()
+    start = DateTimeField()
+    end = DateTimeField()
+    count = IntField()
 
 
 def spread_data(data):

--- a/agent/monitoring/services.py
+++ b/agent/monitoring/services.py
@@ -8,6 +8,10 @@ from monitoring.models import CPU, Memory, Network, Storage, Datas, Devices
 
 
 def save_database(msg):
+    from app import is_connected
+    if not is_connected:
+        print('Failed to connect mongodb. so messages would not be saved on database.')
+        return
     try:
         cpu = CPU(kernel=msg['cpu']['kernel'], user=msg['cpu']['user'],
                   irq=msg['cpu']['irq'], nrCore=msg['cpu']['nrCore'],
@@ -178,7 +182,7 @@ def get_dashboard_data(request_id, target_addr):
 
 def stop_command_run(request_id):
     result = dict(result=0, data='stop success', errMsg='')
-    stop_event = request_id + '_stop';
+    stop_event = request_id + '_stop'
     if RequestManager.get_request_status(request_id):
         RequestManager.stop_request(request_id)
         emit(stop_event, result)
@@ -190,4 +194,3 @@ def stop_command_run(request_id):
 
 def health_check(target_addr, request_id):
     get_data_by_command(target_addr, request_id, 'GUIDER list')
-

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -5,7 +5,6 @@ bson==0.5.8
 Click==7.0
 Flask==1.1.1
 Flask-Cors==3.0.8
-flask-mongoengine==0.9.5
 Flask-PyMongo==2.3.0
 Flask-RESTful==0.3.7
 Flask-Script==2.0.6


### PR DESCRIPTION
Handle ServerSelectionTimeOut, ConnectionFailure errors with respect to mongoDB.

this closes #194
this closes #188
this closes #173


> In PyMongo 3, the MongoClient constructor no longer blocks while connecting to the server or servers, and it no longer raises ConnectionFailure if they are unavailable, nor ConfigurationError if the user’s credentials are wrong. Instead, the constructor returns immediately and launches the connection process on background threads. The connect option is added to control whether these threads are started immediately, or when the client is first used. [링크](https://api.mongodb.com/python/current/migrate-to-pymongo3.html#mongoclient-connects-asynchronously)

이거 때문에 try except로 에러 핸들링이 안되는 거 였네요..
추가로 flask-mongoengine을 따로 쓸 이유가 없어서(더 이상 프로젝트가 maintained가 안됨) 일단 dependencies에서 제거 했습니다. (mongoengine 사용중)

`app.__init__` 에 몽고 디비에 연결 여부를 검사한 다음에(조금 오래 걸립니다.) 결과를 is_connected라는 변수에 저장하고 컨트롤러와 서비스에서 `from app import is_connected`처럼 하는 형태로 상태를 불러오게 했는데 혹시 더 좋은 방법이 있을까요??