### PR TITLE
fix: Fixed an issue where image files were not committed in admin web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 *.o
 *.so
 *.swp
-*.png
-*.jpg
-*.bmp
 *.out*
 *.dat*
 *.log


### PR DESCRIPTION
Use image files such as .png and .jpg in admin web. However, it is set so that .gitignore cannot reflect image files. I ask for deletion.